### PR TITLE
update to use custom dataclass added to argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ bin/
 lib/
 *.db
 snakemake_executor_flux.egg-info
-snakemake
 env
 .env
 apigen/_build

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ These are general instructions for the naming of your library.
 1. The plugin module should have the prefix `snakemake_executor_<name>`
 2. The name of your executor is assumed to be the last term (e.g., `<name>` or "flux" here)
 3. The library name, if provided via pypi to be installed with pip, should follow the same convention, but using dashes, e.g., "snakemake-executor-flux"
+4. Arguments are provided in two ways:
+  a. Via a custom data class that is namespaced to your executor OR
+  b. Using an already established Snakemake argument (e.g., `--preemtible` or `--container-image`)
+
+The above will be discussed in more detail.
 
 ### How does it work?
 
@@ -120,19 +125,137 @@ setup to drastically change. Our setup supports:
 
  - Install of any custom number of executor plugins
  - Choosing to use one by specifying it's name with `--executor <name>`
- - Adding custom arguments or groups given selection of the plugin
+ - Defining a custom data class that is added as additional arguments (and later parsed back into the class)
  - Doing additional parsing to the derived args if the plugin is selected
 
 Each plugin is expected to have, at the top level of the module (e.g., `snakemake_executor_example.<func>`), the following functions or attributes for Snakemake to find:
 
- - `add_args`: will take as input the parser, and the plugin is free to modify it to add additional arguments or groups. Note that you cannot create a conflicting argument (e.g., one with the same name).
- - `parse`: takes the parsed arguments "args" and does any changes that are needed for the executor. This could be where defaults are adjusted depending on the choice.
+ - A custom dataclasses.dataclass with namespaced executor plugin arguments
+ - `add_args`: will take as input the parser, and add the dataclass as namespaced arguments (e.g, `<plugin>_arg`).
+ - `parse`: takes the parsed arguments "args" and converts back to dataclass, and does any changes that are needed for the executor. This could be where defaults are adjusted depending on the choice.
  - `local_executor`: should be akin to a "pointer" to whatever class you want Snakemake to use for your local executor. For most, this can be the `snakemake.executor.CPUExecutor`
  - `executor`: should reference your custom executor class, which is expected to take a core set of arguments plug the original args spec. As an example:
 
+More detail on the above is provided below.
+
+#### dataclasses.dataclass
+
+Your executor plugin is driven by the custom dataclass. We chose this design because it needs to be possible
+to interact with the executor from within Python (in which case you would create the dataclass) or from
+the command line (in which case we convert from the dataclass to argparse and back again)! As an example,
+here is a very basic way to define custom arguments for your executor plugin via a dataclass:
+
 ```python
-elif args.executor and args.executor in executor_plugins:
-    executor = executor_plugins[args.executor]
+import snakemake.plugins as plugins
+from typing import Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecutorParameters:
+    flux_help: Optional[str] = None
+    flux_description: Optional[str] = None
+```
+
+In the above, it is very important that:
+
+- You define the types to be Optional, otherwise Snakemake will error that the argument is required
+- You also provide a default argument, otherwise the same will happen!
+
+The above will add the following (string) arguments to the parser:
+
+```
+  --flux-help FLUX_HELP
+  --flux-description FLUX_DESCRIPTION
+```
+
+You can currently add arguments for str, int, float, or bool. Advanced types can be added
+when needed or requested. This is done by way of support from [argparse-dataclass](https://github.com/mivade/argparse_dataclass/),
+which should be added to your setup.py (or in the case of the example here, is in version.py):
+
+```python
+INSTALL_REQUIRES = (
+    ("snakemake", {"min_version": None}),
+    ("argparse-dataclass", {"min_version": None}),
+)
+```
+
+#### add_args
+
+As mentioned above, `add_args` is a function that takes the parser, and is free to modify
+it. Importantly, you should return the parser with your added Dataclass, which
+is as simple as doing the following:
+
+```python
+def add_args(parser):
+    """
+    Allow the custom executor to modify the parser as needed.
+
+    Note that we do not here, but it's recommended to use your custom
+    parser GROUP_IDENTIFIER as a prefix to honor the namespace.
+    """
+    _add_dataclass_options(ExecutorParameters, parser)
+```
+
+#### parse
+
+Parse is going to discover your namespaced arguments on the dataclass,
+and parse them back into the dataclass to pass onto the executor. For
+most use cases, you can call the provided plugin function
+`plugins.args_to_dataclass`:
+
+```python
+import snakemake.plugins as plugins
+
+def parse(args):
+    """
+    Custom parsing of arguments for the Flux executor.
+
+    For arguments that are scoped to your custom data class, this
+    function should map these ExecutorParameters from the parsed args
+    back into the dataclass above. This will be passed to the
+    executor. For shared args (not part of your dataclass) you can also
+    modify args as needed here, assuming that  the user has selected
+    your executor (it is only possible to select one).
+    """
+    # Since flux is already a known executor, just set the --flux flag to true
+    # Although we will use the module, this will prepare other settings
+    args.flux = True
+
+    # Parse namespaced args (starting with flux_) into dataclass.
+    # See plugins.py in snakemake to customize here
+    return plugins.args_to_dataclass(args, ExecutorParameters)
+```
+
+See the function in snakemake.plugins if you want more advanced usage (and to modify
+it for your purposes). You are also free to modify the dataclass here as you see fit!
+It will be passed to your custom executor as `executor_args`.
+
+#### local_executor and executor
+
+These are mostly just handles to point to the classes you want snakemake to use
+for your executor and local_executor. As an example:
+
+```python
+from snakemake.executors import CPUExecutor
+from .executor import FluxExecutor
+
+# Common plugin interfaces to get the executor classes
+# These could be functions if the import needs to happen locally
+local_executor = CPUExecutor
+executor = FluxExecutor
+```
+
+### scheduler logic
+
+In the snakemake.scheduler, if we find that the user has provided the `--executor <name>` flag,
+and it's an executor known to Snakemake, we will use your `local_executor` and `executor` classes
+you've defined, and pass along expected (global) arguments along with your dataclass.
+
+```python
+# We have chosen an executor custom plugin
+elif executor_args is not None and executor_args._executor_name in executor_plugins:
+    executor = executor_plugins[executor_args._executor_name]
     self._local_executor = executor.local_executor(
         workflow,
         dag,
@@ -149,8 +272,8 @@ elif args.executor and args.executor in executor_plugins:
         printreason=printreason,
         quiet=quiet,
         printshellcmds=printshellcmds,
-        args=args,
-    )
+        executor_args=executor_args,
+)
 ```
 
 Likely we can adjust this spec depending on what the average plugin executor needs. The current design of snakemake

--- a/snakemake_executor_flux/__init__.py
+++ b/snakemake_executor_flux/__init__.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass
+from typing import Optional
+
 import snakemake.plugins as plugins
+from argparse_dataclass import _add_dataclass_options
 from snakemake.executors import CPUExecutor
 
 from snakemake_executor_flux.version import __version__
@@ -12,6 +16,17 @@ assert __version__
 local_executor = CPUExecutor
 executor = FluxExecutor
 
+# You can create a Dataclass that will translate to an argument group
+# It is recommended to namespace the arguments with your group
+# identifier, e.g.,
+# GROUP_IDENTIFIER = plugins.get_plugin_name(__file__)
+
+
+@dataclass
+class ExecutorParameters:
+    flux_help: Optional[str] = None
+    flux_description: Optional[str] = None
+
 
 # Common plugin interfaces for custom argument addition and parsing
 
@@ -23,20 +38,24 @@ def add_args(parser):
     Note that we do not here, but it's recommended to use your custom
     parser GROUP_IDENTIFIER as a prefix to honor the namespace.
     """
-    # This is the group identifier for argparse
-    # It matches the snakemake_executor_<name>
-    GROUP_IDENTIFIER = plugins.get_plugin_name(__file__)
-    # You could create a group argument here.
-    assert GROUP_IDENTIFIER
+    _add_dataclass_options(ExecutorParameters, parser)
 
 
 def parse(args):
     """
     Custom parsing of arguments for the Flux executor.
 
-    Modify args as needed here, assuming that the user has selected
+    For arguments that are scoped to your custom data class, this
+    function should map these ExecutorParameters from the parsed args
+    back into the dataclass above. This will be passed to the
+    executor. For shared args (not part of your dataclass) you can also
+    modify args as needed here, assuming that  the user has selected
     your executor (it is only possible to select one).
     """
     # Since flux is already a known executor, just set the --flux flag to true
     # Although we will use the module, this will prepare other settings
     args.flux = True
+
+    # Parse namespaced args (starting with flux_) into dataclass.
+    # See plugins.py in snakemake to customize here
+    return plugins.args_to_dataclass(args, ExecutorParameters)

--- a/snakemake_executor_flux/executor.py
+++ b/snakemake_executor_flux/executor.py
@@ -40,7 +40,7 @@ class FluxExecutor(ClusterExecutor):
         printreason=False,
         quiet=False,
         printshellcmds=False,
-        args=None,
+        executor_args=None,
     ):
         super().__init__(
             workflow,

--- a/snakemake_executor_flux/version.py
+++ b/snakemake_executor_flux/version.py
@@ -12,7 +12,10 @@ LICENSE = "LICENSE"
 
 # Since we assume wanting Singularity and lmod, we require spython and Jinja2
 
-INSTALL_REQUIRES = (("snakemake", {"min_version": None}),)
+INSTALL_REQUIRES = (
+    ("snakemake", {"min_version": None}),
+    ("argparse-dataclass", {"min_version": None}),
+)
 
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
 


### PR DESCRIPTION
Add support for custom dataclass. The way this works is that:

1. The custom executor defines a custom dataclass
2. The dataclass (via argparse-dataclass) is converted to be in the args space of Snakemake
3. After parsing, we convert back to the dataclass
4. The dataclass is passed to the custom executor proper!